### PR TITLE
set rasterize=True in sea level example

### DIFF
--- a/sea-surface-height.ipynb
+++ b/sea-surface-height.ipynb
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds.sla.sel(time='1982-08-07', method='nearest').hvplot(colormap='RdBu_r', width=900, height=550)"
+    "ds.sla.sel(time='1982-08-07', method='nearest').hvplot(colormap='RdBu_r', width=900, height=550, rasterize=True)"
    ]
   },
   {
@@ -237,13 +237,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sla_std.hvplot(colormap='viridis', width=900, height=550)"
+    "sla_std.hvplot(colormap='viridis', width=900, height=550, rasterize=True)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Speed up hvplots by adding `rasterize=True`.  This turns a 20 second plot into a 5 second plot, similar to matplotlib, at least on my testing.  Addresses #24 