### PR TITLE
Use Dask Gateway

### DIFF
--- a/SOSE_tracer_budgets.ipynb
+++ b/SOSE_tracer_budgets.ipynb
@@ -24,8 +24,11 @@
    "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=30)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(30)\n",
     "cluster"
    ]
   },
@@ -81,7 +84,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_zarr(gcsfs.GCSMap('pangeo-data/SOSE'))\n",
+    "from intake import open_catalog\n",
+    "\n",
+    "cat = open_catalog(\"https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = cat.ocean.SOSE.to_dask()\n",
     "ds"
    ]
   },
@@ -714,7 +728,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -728,7 +742,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - ipywidgets
   - ipyleaflet
   - graphviz
-  - dask-kubernetes
+  - dask-gateway
   - pip:
     - git+https://github.com/xgcm/xgcm.git
     - git+https://github.com/pydata/xarray.git

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,15 +12,15 @@ dependencies:
   - dask
   - distributed
   - gcsfs
-  - intake::intake
-  - intake::intake-xarray
+  - intake
+  - intake-xarray
   - s3fs
   - scikit-image
   - scikit-learn
   - dask-ml
   - bokeh
-  - pyviz/label/earthsim::holoviews
-  - pyviz/label/earthsim::panel
+  - holoviews
+  - panel
   - geoviews
   - hvplot
   - rasterio

--- a/cesm-pop-highres-ocean.ipynb
+++ b/cesm-pop-highres-ocean.ipynb
@@ -28,10 +28,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from intake import open_catalog\n",
+    "\n",
+    "cat = open_catalog(\"https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load High Resolution Ocean Surface Fields in Zarr Format"
+    "### Load High Resolution Ocean Surface Fields\n",
+    "\n",
+    "Stored on Google Cloud Storage in Zarr format. Accessed using intake."
    ]
   },
   {
@@ -40,8 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_zarr(gcsfs.GCSMap('pangeo-data/cesm/hybrid_v5_rel04_BC5_ne120_t12_pop62'),\n",
-    "                  decode_times=False)\n",
+    "ds = cat.ocean.CESM_POP.CESM_POP_hires_control.to_dask()\n",
     "ds"
    ]
   },
@@ -379,13 +391,6 @@
    "source": [
     "plt.bar(bins[:-1], np.log10(hc), width=(bins[1]-bins[0]))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -404,7 +409,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/cesm-pop-highres-ocean.ipynb
+++ b/cesm-pop-highres-ocean.ipynb
@@ -316,8 +316,12 @@
    "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=20)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(20)\n",
     "cluster"
    ]
   },
@@ -386,7 +390,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -400,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/cm26.ipynb
+++ b/cm26.ipynb
@@ -28,6 +28,7 @@
     "import matplotlib.pyplot as plt\n",
     "import holoviews as hv\n",
     "import datashader\n",
+    "import intake\n",
     "from holoviews.operation.datashader import regrid, shade, datashade\n",
     "\n",
     "hv.extension('bokeh', width=100)"
@@ -49,8 +50,11 @@
    "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=40)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(40)\n",
     "cluster"
    ]
   },
@@ -89,15 +93,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#experiment = 'one_percent'\n",
-    "experiment = 'control'\n",
+    "from intake import open_catalog\n",
     "\n",
-    "# Load with Cloud object storage\n",
-    "import gcsfs\n",
-    "gcsmap = gcsfs.mapping.GCSMap('pangeo-data/cm2.6/%s/temp_salt_u_v-5day_avg/' % experiment)\n",
-    "ds = xr.open_zarr(gcsmap, decode_cf=True, decode_times=False)\n",
-    "\n",
-    "# Print dataset\n",
+    "cat = open_catalog(\"https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Can also select GFDL_CM2_6_one_percent_ocean\n",
+    "ds = cat.ocean.GFDL_CM2_6.GFDL_CM2_6_control_ocean.to_dask()\n",
     "ds"
    ]
   },
@@ -188,7 +196,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -202,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/custom-computations.ipynb
+++ b/custom-computations.ipynb
@@ -21,8 +21,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=10)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -171,9 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "del L"
@@ -223,7 +224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/dask-array.ipynb
+++ b/dask-array.ipynb
@@ -17,8 +17,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=10)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -114,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/landsat8-cog-ndvi-hvplot.ipynb
+++ b/landsat8-cog-ndvi-hvplot.ipynb
@@ -39,7 +39,7 @@
     "import xarray as xr\n",
     "import requests\n",
     "\n",
-    "from dask_kubernetes import KubeCluster\n",
+    "from dask_gateway import Gateway\n",
     "from dask.distributed import Client\n",
     "from dask.distributed import wait, progress\n",
     "\n",
@@ -197,8 +197,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Click on the 'Dashboard link' to monitor calculation progress\n",
-    "cluster = KubeCluster(n_workers=10)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -209,7 +212,8 @@
    "outputs": [],
    "source": [
     "# Attach Dask to the cluster\n",
-    "client = Client(cluster)"
+    "client = Client(cluster)\n",
+    "client"
    ]
   },
   {
@@ -253,7 +257,7 @@
    "outputs": [],
    "source": [
     "# If we request to compute something or plot these arrays, the necessary data chunks will be accessed on cloud storage:\n",
-    "# Watch the KubeCluster dashboard to see the worker activity when this command is run:\n",
+    "# Watch the Dask dashboard to see the worker activity when this command is run:\n",
     "# Note that no data is stored on the disk here, it's all in memory\n",
     "band1 = da.sel(band=1).persist()\n",
     "progress(band1)"
@@ -380,7 +384,7 @@
     "\n",
     "There is definitely some room for improvement here from a computational efficiency standpoint - in particular the dask chunks are no longer aligned with the image tiles. This is because each image starts at different coordinates and has different shapes, but xarray uses a single chunk size for the entire datasets. There will also be many zeros in this dataset, so future work could take advantage of sparse arrays. \n",
     "\n",
-    "These points aside, our KubeCluster will automatically parallelize our computations for us, so we can not worry too much about optimal efficiency and just go ahead and run our analysis!"
+    "These points aside, our Dask Cluster will automatically parallelize our computations for us, so we can not worry too much about optimal efficiency and just go ahead and run our analysis!"
    ]
   },
   {
@@ -658,7 +662,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/landsat8-cog-ndvi.ipynb
+++ b/landsat8-cog-ndvi.ipynb
@@ -37,7 +37,7 @@
     "import xarray as xr\n",
     "import requests\n",
     "\n",
-    "from dask_kubernetes import KubeCluster\n",
+    "from dask_gateway import Gateway\n",
     "from dask.distributed import Client\n",
     "from dask.distributed import wait, progress\n",
     "\n",
@@ -280,28 +280,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d3039133d0284773834984eeebe4e2d1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HTML(value='<h2>KubeCluster</h2>'), HBox(children=(HTML(value='\\n<div>\\n  <style scoped>\\n    .…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Select 10 'workers' under 'manual scaling' menu below and click 'Scale'\n",
-    "# Click on the 'Dashboard link' to monitor calculation progress\n",
-    "cluster = KubeCluster(n_workers=10)\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -312,7 +297,8 @@
    "outputs": [],
    "source": [
     "# Attach Dask to the cluster\n",
-    "client = Client(cluster)"
+    "client = Client(cluster)\n",
+    "client"
    ]
   },
   {
@@ -981,7 +967,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/machine-learning.ipynb
+++ b/machine-learning.ipynb
@@ -22,8 +22,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=10)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -57,7 +60,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dask_ml.joblib  # register the distriubted backend\n",
     "from sklearn.datasets import make_classification\n",
     "from sklearn.svm import SVC\n",
     "from sklearn.model_selection import GridSearchCV\n",
@@ -101,7 +103,6 @@
     "grid_search = GridSearchCV(SVC(gamma='auto', random_state=0, probability=True),\n",
     "                           param_grid=param_grid,\n",
     "                           return_train_score=False,\n",
-    "                           iid=True,\n",
     "                           n_jobs=-1)"
    ]
   },
@@ -125,7 +126,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "\n",
     "with joblib.parallel_backend('dask', scatter=[X, y]):\n",
     "    grid_search.fit(X, y)"
@@ -283,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/mom6_cesm.ipynb
+++ b/mom6_cesm.ipynb
@@ -45,8 +45,11 @@
    "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=10)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -85,13 +88,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load with Cloud object storage\n",
-    "import gcsfs\n",
-    "gcsmap = gcsfs.mapping.GCSMap('pangeo-data/MOM6.cesm/')\n",
-    "ds = xr.open_zarr(gcsmap, decode_times=False)\n",
+    "from intake import open_catalog\n",
     "\n",
-    "# Print dataset\n",
-    "print(ds)"
+    "cat = open_catalog(\"https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = cat.ocean.cesm_mom6_example.to_dask()\n",
+    "ds"
    ]
   },
   {
@@ -211,9 +220,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:conda]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-conda-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -225,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/scikit-image-example.ipynb
+++ b/scikit-image-example.ipynb
@@ -16,8 +16,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=40)\n",
+    "from dask_gateway import Gateway\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -201,7 +204,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -215,7 +218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/sea-surface-height.ipynb
+++ b/sea-surface-height.ipynb
@@ -25,7 +25,6 @@
    "source": [
     "import numpy as np\n",
     "import xarray as xr\n",
-    "import gcsfs\n",
     "import holoviews as hv\n",
     "import hvplot.xarray\n",
     "import hvplot.pandas"
@@ -46,9 +45,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gcsmap = gcsfs.mapping.GCSMap('pangeo-data/dataset-duacs-rep-global-merged-allsat-phy-l4-v3-alt')\n",
-    "ds = xr.open_zarr(gcsmap)\n",
-    "ds"
+    "from intake import open_catalog\n",
+    "\n",
+    "cat = open_catalog(\"https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml\")"
    ]
   },
   {
@@ -57,11 +56,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "### Alternate method to load the data using Intake\n",
-    "### Where the remote YAML spec points to the data on GCS\n",
-    "# import intake\n",
-    "# ds = intake.Catalog('https://raw.githubusercontent.com/pangeo-data/pangeo/master/gce/catalog.yaml').sea_surface.to_dask()\n",
-    "# ds"
+    "ds = cat.ocean.sea_surface_height.to_dask()\n",
+    "ds"
    ]
   },
   {
@@ -97,9 +93,11 @@
    "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
+    "from dask_gateway import Gateway\n",
     "\n",
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=20)\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(10)\n",
     "cluster"
    ]
   },
@@ -257,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/trimesh_hurricane.ipynb
+++ b/trimesh_hurricane.ipynb
@@ -17,7 +17,7 @@
     "%matplotlib inline\n",
     "\n",
     "from dask.distributed import Client, progress\n",
-    "from dask_kubernetes import KubeCluster\n",
+    "from dask_gateway import Gateway\n",
     "import xarray as xr\n",
     "import numpy as np"
    ]
@@ -35,24 +35,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster = KubeCluster()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cluster.scale(25);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(25)\n",
     "cluster"
    ]
   },
@@ -373,7 +358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/xarray-data.ipynb
+++ b/xarray-data.ipynb
@@ -39,9 +39,11 @@
    "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
+    "from dask_gateway import Gateway\n",
     "\n",
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=40)\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()\n",
+    "cluster.scale(40)\n",
     "cluster"
    ]
   },
@@ -302,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This changes the example notebooks to use dask gateway, which has been deployed to the staging binder and will be added to the prod binder.

[![Binder](https://staging.binder.pangeo.io/badge_logo.svg)](https://staging.binder.pangeo.io/v2/gh/TomAugspurger/pangeo-example-notebooks/gateway)

Additional notes

* Updated some examples to use intake rather than the (now deleted) paths to the old GCS buckets
* Some of the examples are currently failing until holoviews gets out a bokeh 2.0+ compatible release.

cc @jhamman